### PR TITLE
Add some themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,5 +18,18 @@ Here's mine!
   * **Theme:** choose a color theme by including `?theme=color` after your username. 
 Current color options are `blue`, `red`, `green`, and `hotdog`.
 
+
+* `theme=red`
+<img width="111" alt="Screen Shot 2020-07-12 at 15 02 28" src="https://user-images.githubusercontent.com/279389/87257569-dea4ee00-c450-11ea-9b30-7c7a18cf3db2.png">
+
+* `theme=blue`
+<img width="110" alt="Screen Shot 2020-07-12 at 15 02 40" src="https://user-images.githubusercontent.com/279389/87257570-e49acf00-c450-11ea-816a-21d94c8ada93.png">
+
+* `theme=green`  
+<img width="110" alt="Screen Shot 2020-07-12 at 15 02 49" src="https://user-images.githubusercontent.com/279389/87257576-ef556400-c450-11ea-9480-a9649b49a817.png">
+
+* `theme=hotdog` (:joy:) 
+<img width="109" alt="Screen Shot 2020-07-12 at 15 03 03" src="https://user-images.githubusercontent.com/279389/87257581-f3818180-c450-11ea-8e39-dd15db6b0388.png">
+
 ## Contributing
 randos.online is Open Source Software. To make changes, please submit a Pull Request! 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ Here's mine!
 
 [![pmn's badge](https://www.randos.online/u/pmn)](https://randos.online/u/pmn/next)
 
+## Configuration
+  * **Theme:** choose a color theme by including `?theme=color` after your username. 
+Current color options are `blue`, `red`, `green`, and `hotdog`.
+
 ## Contributing
 randos.online is Open Source Software. To make changes, please submit a Pull Request! 
-
-## Configuration
-There's no configuration at this time...

--- a/src/badge.svg.tmpl
+++ b/src/badge.svg.tmpl
@@ -1,7 +1,7 @@
 <svg width="125" height="32" viewBox="0 0 125 32" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="88" height="31" fill="$background"/>
-<rect y="24" width="88" height="7" fill="$textColor"/>
-<text fill="$brandColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="8" letter-spacing="0em"><tspan x="39" y="30.2344">randos.online</tspan></text>
+<rect y="24" width="88" height="7" fill="$brandColor"/>
+<text fill="$brandTextColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="8" letter-spacing="0em"><tspan x="39" y="30.2344">randos.online</tspan></text>
 <text fill="$textColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="9.41797">$views views</tspan></text>
 <text fill="$textColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="21.418">$username</tspan></text>
 </svg>

--- a/src/badge.svg.tmpl
+++ b/src/badge.svg.tmpl
@@ -1,7 +1,7 @@
 <svg width="125" height="32" viewBox="0 0 125 32" fill="none" xmlns="http://www.w3.org/2000/svg">
-<rect width="88" height="31" fill="#E7F4FF"/>
-<rect y="24" width="88" height="7" fill="#445F77"/>
-<text fill="white" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="8" letter-spacing="0em"><tspan x="39" y="30.2344">randos.online</tspan></text>
-<text fill="#2F3F4E" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="9.41797">$views views</tspan></text>
-<text fill="#2F3F4E" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="21.418">$username</tspan></text>
+<rect width="88" height="31" fill="$background"/>
+<rect y="24" width="88" height="7" fill="$textColor"/>
+<text fill="$brandColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="8" letter-spacing="0em"><tspan x="39" y="30.2344">randos.online</tspan></text>
+<text fill="$textColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="9.41797">$views views</tspan></text>
+<text fill="$textColor" xml:space="preserve" style="white-space: pre" font-family="sans-serif" font-size="10" letter-spacing="0em"><tspan x="2" y="21.418">$username</tspan></text>
 </svg>

--- a/src/index.html
+++ b/src/index.html
@@ -18,18 +18,29 @@
             top: 0;
             right: 0;
         }
+
     </style>
 </head>
 <body>
     <div class="content">
         <h1>randos.online</h1>
         <h3>A collection of randos from the internet</h3>
-        <div>
-            To add the counter to your GitHub profile, use this markdown (be sure to replace <code>YourUserName</code> with your GitHub username):<br>
-            <code>
+        <p>
+            To add the counter to your GitHub profile, use this markdown (be sure to replace <code >YourUserName</code> with your GitHub username):<br>
+            <code class="example">
                 [![some alt text](https://www.randos.online/u/YourUserName)](https://randos.online/u/YourUserName/next)
             </code>
-        </div>
+        </p>
+
+        <p class="configuration">
+            <h3>Configuration options:</h3>
+            <ul>
+                <li>
+                    <strong>Theme:</strong> choose a color theme by including <code>?theme=color</code> after your username. 
+                    Current color options are <code>blue</code>, <code>red</code>, <code>green</code>, and <code>hotdog</code>.
+                </li>
+            </ul>
+        </p>
         <div class="recent">
             <h3>recent randos:</h3>
             <ul>

--- a/src/randos.nim
+++ b/src/randos.nim
@@ -1,4 +1,3 @@
-import logging
 import jester
 import strutils
 import db_sqlite
@@ -41,7 +40,10 @@ proc renderIndex(): string =
 proc renderBadge(theme: string): string =
     let tmpl = readfile("badge.svg.tmpl")
     let colors = themes.getTheme(theme)
-    result = multiReplace(tmpl, [("$background", colors.background), ("$textColor", colors.text), ("$brandColor", colors.brand)])
+    result = multiReplace(tmpl, [("$background", colors.background), 
+                                    ("$textColor", colors.text), 
+                                    ("$brandColor", colors.brand),
+                                    ("$brandTextColor", colors.brandtext)])
     
 proc serveUserBadge(username: string, theme="default"): string =
     let tmpl = renderBadge(theme)
@@ -59,7 +61,7 @@ routes:
         var theme = "default"
         if request.params.hasKey("theme"):
             theme = request.params["theme"]
-            
+
         recordView(@"username")
         resp(Http200, [("Content-Type", "image/svg+xml"), ("Cache-Control", "no-cache")], serveUserBadge(@"username", theme))
     get "/u/@username/next":

--- a/src/themes.nim
+++ b/src/themes.nim
@@ -2,14 +2,19 @@ import tables
 
 type 
     Theme* = object
-        background*, brand*, text*: string
+        background*, brand*, brandtext*, text*: string
 
-const default = Theme(background: "#E7F4FF", brand: "#FFFFFF", text: "#2F3F4E")
-const red = Theme(background: "#FF0000", brand: "#000000", text: "#FFFFFF")
-const blue = Theme(background: "#0000FF", brand: "#000000", text: "#FFFFFF")
-const green = Theme(background: "#00FF00", brand: "#000000", text: "#FFFFFF")
+const default = Theme(background: "#E7F4FF", brand: "#FFFFFF", brandtext: "#FFFFFF", text: "#2F3F4E")
+const red = Theme(background: "#e6003a", brand: "#9a0027", brandtext: "#FFFFFF", text: "#FFFFFF")
+const blue = Theme(background: "#0080ff", brand: "#005ab3", brandtext: "#FFFFFF", text: "#FFFFFF")
+const green = Theme(background: "#ACDF87", brand: "#1E5631", brandtext: "#FFFFFF", text: "#1E5631")
+const hotdog = Theme(background: "#FF0000", brand: "#FEFF00", brandtext: "#000", text: "#FEFF00")
 
-const themes = {"default": default, "red": red, "blue": blue, "green": green}.toTable()
+const themes = {"default": default, 
+                "red": red, 
+                "blue": blue, 
+                "green": green,
+                "hotdog": hotdog}.toTable()
 
 proc getTheme*(name: string): Theme =
     result = themes.getOrDefault(name, default)

--- a/src/themes.nim
+++ b/src/themes.nim
@@ -4,7 +4,7 @@ type
     Theme* = object
         background*, brand*, brandtext*, text*: string
 
-const default = Theme(background: "#E7F4FF", brand: "#FFFFFF", brandtext: "#FFFFFF", text: "#2F3F4E")
+const default = Theme(background: "#E7F4FF", brand: "#445F77", brandtext: "#FFFFFF", text: "#2F3F4E")
 const red = Theme(background: "#e6003a", brand: "#9a0027", brandtext: "#FFFFFF", text: "#FFFFFF")
 const blue = Theme(background: "#0080ff", brand: "#005ab3", brandtext: "#FFFFFF", text: "#FFFFFF")
 const green = Theme(background: "#ACDF87", brand: "#1E5631", brandtext: "#FFFFFF", text: "#1E5631")

--- a/src/themes.nim
+++ b/src/themes.nim
@@ -1,0 +1,15 @@
+import tables
+
+type 
+    Theme* = object
+        background*, brand*, text*: string
+
+const default = Theme(background: "#E7F4FF", brand: "#FFFFFF", text: "#2F3F4E")
+const red = Theme(background: "#FF0000", brand: "#000000", text: "#FFFFFF")
+const blue = Theme(background: "#0000FF", brand: "#000000", text: "#FFFFFF")
+const green = Theme(background: "#00FF00", brand: "#000000", text: "#FFFFFF")
+
+const themes = {"default": default, "red": red, "blue": blue, "green": green}.toTable()
+
+proc getTheme*(name: string): Theme =
+    result = themes.getOrDefault(name, default)


### PR DESCRIPTION
Create some theme options badges. Resolves #1.

* `theme=red`
<img width="111" alt="Screen Shot 2020-07-12 at 15 02 28" src="https://user-images.githubusercontent.com/279389/87257569-dea4ee00-c450-11ea-9b30-7c7a18cf3db2.png">

* `theme=blue`
<img width="110" alt="Screen Shot 2020-07-12 at 15 02 40" src="https://user-images.githubusercontent.com/279389/87257570-e49acf00-c450-11ea-816a-21d94c8ada93.png">

* `theme=green`  
<img width="110" alt="Screen Shot 2020-07-12 at 15 02 49" src="https://user-images.githubusercontent.com/279389/87257576-ef556400-c450-11ea-9480-a9649b49a817.png">

* `theme=hotdog` (:joy:) 
<img width="109" alt="Screen Shot 2020-07-12 at 15 03 03" src="https://user-images.githubusercontent.com/279389/87257581-f3818180-c450-11ea-8e39-dd15db6b0388.png">

